### PR TITLE
Change license to "Unlicense"

### DIFF
--- a/blake2.cabal
+++ b/blake2.cabal
@@ -1,7 +1,7 @@
 name:          blake2
 version:       0.3.0
 synopsis:      A library providing BLAKE2
-license:       PublicDomain
+license:       Unlicense
 license-file:  LICENSE
 author:        John Galt
 maintainer:    jgalt@centromere.net


### PR DESCRIPTION
Newer versions of cabal won't accept "PublicDomain" as a license identifier; the actual license file here seems to more accurately be described as "Unlicense" anyway.