### PR TITLE
Add basic github actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+on: [push, pull_request]
+
+name: Test
+
+jobs:
+  build:
+    name: Test
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        ghc: ['8.10', '9.0', '9.2', '9.4']
+        os: ['ubuntu-latest', 'macos-latest']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Haskell dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal', 'configurations/ghc-${{ matrix.ghc }}.project') }}
+          restore-keys: |
+              ${{ runner.os }}-${{ matrix.ghc }}-
+              ${{ runner.os }}-
+
+      - uses: haskell/actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+
+      - name: Build
+        run: cabal build all --project-file ./configurations/ghc-${{ matrix.ghc }}.project
+
+      - name: Test
+        run: cabal test all --enable-tests --project-file ./configurations/ghc-${{ matrix.ghc }}.project

--- a/configurations/ghc-8.10.project
+++ b/configurations/ghc-8.10.project
@@ -1,0 +1,4 @@
+packages: .
+
+constraints:
+    base == 4.14.*

--- a/configurations/ghc-9.0.project
+++ b/configurations/ghc-9.0.project
@@ -1,0 +1,4 @@
+packages: .
+
+constraints:
+    base == 4.15.*

--- a/configurations/ghc-9.2.project
+++ b/configurations/ghc-9.2.project
@@ -1,0 +1,4 @@
+packages: .
+
+constraints:
+    base == 4.16.*

--- a/configurations/ghc-9.4.project
+++ b/configurations/ghc-9.4.project
@@ -1,0 +1,4 @@
+packages: .
+
+constraints:
+    base == 4.17.*


### PR DESCRIPTION
Re: #7

Not sure if there's another way that the cool people are doing github actions CI, but this is what I've done on all my projects. (I actually don't use github actions anymore, but up until a few weeks ago this is the setup I used.) The idea is that the `configurations/*.project` files are places to put constraints to make sure that the oldest and newest dependency versions we declare support for are involved somewhere in the build matrix. I've not bothered to add any such constraints yet, will do so if approved once we have a conversation about what this project's dependency support policy ought to be.

I usually don't add macos testing because it's quite a bit slower, but since we've got native dependencies here I figure multiple platforms is probably not a bad idea.